### PR TITLE
Make command prefix configurable and add comment prefix.

### DIFF
--- a/MessageHandler.js
+++ b/MessageHandler.js
@@ -29,7 +29,7 @@ class MessageHandler{
 
         // If this message starts with the comment prefix (and one is set)
         // ignore this message no matter what
-        if (this.commentPrefix.length > 0 && message.startsWith(this.commentPrefix)){
+        if (this.commentPrefix && this.commentPrefix !== "" && message.startsWith(this.commentPrefix)){
             return;
         }
 

--- a/MessageHandler.js
+++ b/MessageHandler.js
@@ -44,7 +44,7 @@ class MessageHandler{
 
         // Special case: listen for this on all channels.
         // (Ensuring you can't lock yourself out.)
-        if(message.match(/^(adventureListenChannel)/)){
+        if(message.match(/^(adventureListenChannel)/i)){
             this.setListenChannel(channelID, true);
             return;
         }
@@ -54,17 +54,17 @@ class MessageHandler{
             return;
         }
 
-        if(message.match(/^(info)/)){
+        if(message.match(/^(info)/i)){
             this.sendInfo(channelID);
-        }else if(message.match(/^(targetChannel)/)){
+        }else if(message.match(/^(targetChannel)/i)){
             this.setTargetChannel(channelID, true);
-        }else if(message.match(/^(start)/)){
+        }else if(message.match(/^(start)/i)){
             if(this.mode == 0){
                 this.attemptToLoadGame(message);
             }else{
                 this.reply("You cannot load a game because a game is already running!");
             }
-        }else if(message.match(/^(quit)|^(q)$/)){
+        }else if(message.match(/^(quit)|^(q)$/i)){
             if(this.mode == 1){
                 this.closeGame();
 
@@ -72,7 +72,7 @@ class MessageHandler{
             }else{
                 this.reply("Nothing to exit from!");
             }
-        }else if(message.match(/^(save)/)){
+        }else if(message.match(/^(save)/i)){
             // disable saving for now
             this.reply("Saving is disabled for now.");
         }else{

--- a/config.json.example
+++ b/config.json.example
@@ -10,5 +10,9 @@
             "prettyName": "Example Name",
             "path": "/tmp/foobar.z5"
         }
-    ]
+    ],
+    "settings": {
+        "commandPrefix": "$",
+        "commentPrefix": "//"
+    }
 }


### PR DESCRIPTION
Motivation: With previous frotz bots I have dedicated a whole channel to the story. I treated **all** input as commands with a prefix for meta-commentary. (Sort of an opt-out rather than opt-in type thing.) I found this makes a more immersive experience. These additions allow that kind of setup by configuring an empty string as the command prefix and using the adventureListenChannel command.

It also accommodates users that just prefer a different prefix, e.g. `!command`

The meta-commentary feature isn't particularly useful unless you are using my kind of setup.