### PR TITLE
Tweaked handling of removing the last line

### DIFF
--- a/MessageHandler.js
+++ b/MessageHandler.js
@@ -363,11 +363,16 @@ class MessageHandler{
         var output = "";
 
         for(var x = 0; x < splitRaw.length; x++){
-            // if we're cleaning up the output for display, we can skip the last
-            // line as it just contains the ">" prompt
-            if(forDisplay && x == splitRaw.length - 1) {
+            
+            var curr = splitRaw[x];
+
+            // if we're cleaning up the output for display, we can skip the last 
+            // line as it just contains the ">" prompt, unlessit contains other 
+            // characters
+            if(forDisplay && x == splitRaw.length - 1 && curr.match(/^[\s>]*$/)) {
                 continue;
             }
+            
 
             var curr = splitRaw[x];
 


### PR DESCRIPTION
The bot was configured to remove the last line of output as it usually contained just a ">" character. However, some games in some circumstances do include more info on the last line. One example is 9:05. http://ifdb.tads.org/viewgame?id=qzftg3j8nh5f34i2

For most of the game, the bot handles it fine but after you start driving it asks you some yes or no questions where the text on the last line along with the >.

To deal with this situation, yet hold onto the benefits of the previous version, I've added a check when removing the last line. This ensure that the last line consists of nothing except whitespace and ">" symbols. If this is true, the line is removed, if not, the line is left in.