### PR TITLE
Added "-m" argument to suppress "MORE"

### DIFF
--- a/MessageHandler.js
+++ b/MessageHandler.js
@@ -204,7 +204,7 @@ class MessageHandler{
         };
         // Create child process (we'll need to keep track of it in case we
         // need to kill it in the future.
-        this.game.child = spawn('dfrotz', [gameConfig.path]);
+        this.game.child = spawn('dfrotz', ["-m", gameConfig.path]);
 
         // Setup stream from frotz's stdout so that we can get its output
         this.game.child.stdout.on('data', (chunk) => {


### PR DESCRIPTION
Dumb Frotz has a feature where if you add "-m" as an argument, it will supress and skip over all "MORE" parts. I've added this argument to the spawning of dfrotz so that the bot will not be tripped up this way.