### PR TITLE
Add Better Warning Message About Missing Game Files

### DIFF
--- a/src/Logger.js
+++ b/src/Logger.js
@@ -1,0 +1,15 @@
+/**
+ * Simple wrapper around native console.log in order to make it test-able.
+ */
+class Logger {
+
+  /**
+   * @param {string} message
+   */
+  log(message) {
+    console.log(message);
+  }
+
+}
+
+module.exports = Logger;

--- a/src/client-spawner.js
+++ b/src/client-spawner.js
@@ -1,5 +1,6 @@
 const MessageHandler = require("./MessageHandler.js");
 const Discord = require("discord.js");
+const Logger = require("./Logger.js");
 
 module.exports = function(appConfig) {
   const client = new Discord.Client();
@@ -19,7 +20,7 @@ module.exports = function(appConfig) {
 
   client.once("ready", () => {
     console.log(`Logged in as ${client.user.username} (${client.user.id})`);
-    messageHandler = new MessageHandler(client, appConfig);
+    messageHandler = new MessageHandler(client, new Logger(), appConfig);
 
     if (messageHandler.mode == 1 && messageHandler.game) {
       messageHandler.setBotOnline(messageHandler.game.config.prettyName);

--- a/test/DiscordClientMock.js
+++ b/test/DiscordClientMock.js
@@ -15,6 +15,30 @@ class DiscordClientMock {
     this.lastMessage = config;
   }
 
+  /**
+   * @return {DiscordChannelMock}
+   */
+  mockChannel() {
+    return new DiscordChannelMock(this);
+  }
+
+}
+
+class DiscordChannelMock {
+  /**
+   * @param {DiscordClientMock} clientMock
+   */
+  constructor(clientMock) {
+    this.clientMock = clientMock;
+    this.lastMessage = null;
+  }
+
+  /**
+   * @param {string} message
+   */
+  send(message) {
+    this.lastMessage = message;
+  }
 }
 
 class DiscordUserMock {

--- a/test/LoggerMock.js
+++ b/test/LoggerMock.js
@@ -1,0 +1,15 @@
+/**
+ * Fake implementation of the Logger which does nothing when it logs.
+ */
+class FakeLogger {
+
+  /**
+   * @param {string} message
+   */
+  log(message) {
+    // intentionally do nothing
+  }
+
+}
+
+module.exports = {FakeLogger};


### PR DESCRIPTION
Per #43, the error that happens if a game file isn't at the specified path is confusing at best. This PR fixes that by having the bot check the presence of a file ahead of actually trying to load it in `dfrotz`. Also adds better testability in this regard.

Closes #43 