### PR TITLE
Add $qqq, $admin Commands

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -13,6 +13,7 @@
     ],
     "settings": {
         "commandPrefix": "$",
-        "commentPrefix": "//"
+        "commentPrefix": "//",
+        "adminCode": "replacethis"
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ you, so you will have to run it yourself.
     - [Set Target Listening Channel](#set-target-listening-channel)
     - [Start an Adventure](#start-an-adventure)
     - [Quit an Adventure](#quit-an-adventure)
+    - [Set Yourself as Bot Admin](#set-yourself-as-bot-admin)
   - [Development](#development)
     - [Tests](#tests)
     - [Linting](#linting)
@@ -201,6 +202,17 @@ Starts the specified gamename, which is the `name` specified in the config.json.
 
 Quits the current game. Will only work when in game mode (aka when a game has
 been started with the `$start` command).
+
+### Set Yourself as Bot Admin
+
+**Useage:** `$admin [admincode]`
+
+Sets your Discord account (the one that sends the `$admin ...` message) as the
+admin account for the bot. The admin account has special priviledges and can run
+special commands.
+
+You can and should send this message in a private message to the bot, as the
+admin code will be visible in chat history for anyone to see otherwise.
 
 ## Development
 

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,8 @@ you, so you will have to run it yourself.
     - [Start an Adventure](#start-an-adventure)
     - [Quit an Adventure](#quit-an-adventure)
     - [Set Yourself as Bot Admin](#set-yourself-as-bot-admin)
+    - [Kill the Bot](#kill-the-bot)
+  - [Config](#config)
   - [Development](#development)
     - [Tests](#tests)
     - [Linting](#linting)
@@ -213,6 +215,21 @@ special commands.
 
 You can and should send this message in a private message to the bot, as the
 admin code will be visible in chat history for anyone to see otherwise.
+
+### Kill the Bot
+
+**Useage:** `$qqq`
+
+*This command can only be run by a bot admin.*
+
+Stops the currently running game, closes the connection with Discord, and kills
+the bot.
+
+## Config
+
+As mentioned prior, all config should live in `config.json`, and an example
+config is provided for you:
+[`config.json.example`](https://github.com/aeolingamenfel/discord-text-adventure-bot/blob/master/config.json.example)
 
 ## Development
 

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -7,14 +7,22 @@ class Admin {
    * @param {import('discord.js').Client} client
    * @param {import('../utility/StorageManager')} storageManager
    * @param {import('./Logger')} logger
+   * @param {object} appConfig
    */
-  constructor(client, storageManager, logger) {
+  constructor(client, storageManager, logger, appConfig) {
     this.client = client;
     this.storageManager = storageManager;
     this.logger = logger;
     /** @type {import('discord.js').User?} */
     this.adminUser = null;
-    this.code = "";
+    this.appConfig = appConfig;
+    this.code = this.appConfig.settings.adminCode || null;
+
+    if (this.code == null) {
+      this.logger.log(
+        "No admin code was specified in the app config. This means that no "
+        + "admin can be set until a code is specified.");
+    }
 
     this.loadUserFromStorage();
   }
@@ -74,6 +82,13 @@ class Admin {
    * @param {import('discord.js').Message} message
    */
   setAdminUserFromMessage(message) {
+    if (this.code == null) {
+      this.logger.log(
+        "A user tried to become admin, but there is no admin code set in the "
+        + "app config, so I did nothing.");
+      return;
+    }
+
     if (this.hasAdminUser() && this.isAdminUser(message.author)) {
       throw new Error("You are already the admin!");
     }

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -1,0 +1,103 @@
+/**
+ * Manages the bot admin and keeps track of who that is.
+ */
+class Admin {
+
+  /**
+   * @param {import('discord.js').Client} client
+   * @param {import('../utility/StorageManager')} storageManager
+   * @param {import('./Logger')} logger
+   */
+  constructor(client, storageManager, logger) {
+    this.client = client;
+    this.storageManager = storageManager;
+    this.logger = logger;
+    /** @type {import('discord.js').User?} */
+    this.adminUser = null;
+    this.code = "";
+
+    this.loadUserFromStorage();
+  }
+
+  async loadUserFromStorage() {
+    const userID = this.storageManager.get("admin.userid");
+
+    if (!userID) {
+      this.logger.log("Did not find admin user in storage.");
+      return;
+    }
+
+    let user = null;
+    
+    try {
+      user = await this.client.users.fetch(userID);
+    } catch (e) {
+      this.logger.log("Failed to load user from storage:");
+      this.logger.log(e);
+      return;
+    }
+
+    this.adminUser = user;
+  }
+
+  /**
+   * @return {boolean}
+   */
+  hasAdminUser() {
+    return this.adminUser !== null;
+  }
+
+  /**
+   * @param {import('discord.js').User} user
+   * @return {boolean}
+   */
+  isAdminUser(user) {
+    return user.id === this.adminUser.id;
+  }
+
+  /**
+   * @param {import('discord.js').User} user
+   */
+  setAdminUser(user) {
+    this.adminUser = user;
+    this.storageManager.set("admin.userid", this.adminUser.id);
+  }
+
+  /**
+   * The auth mechanism for this bot means that the user that wants to become
+   * the admin must specify a special auth key. This method parses the message,
+   * extracting the key, compares it to the correct key, and sets the admin user
+   * if so.
+   * Message format is expected to be: "$admin supersecretkey1234"
+   * @throws {Error} Throws a Discord-message friendly error if the incorrect
+   * key is specified, or the message format is incorrect.
+   * @param {import('discord.js').Message} message
+   */
+  setAdminUserFromMessage(message) {
+    if (this.hasAdminUser() && this.isAdminUser(message.author)) {
+      throw new Error("You are already the admin!");
+    }
+
+    let code = "";
+
+    try {
+      code = message.cleanContent.split(" ")[1];
+    } catch (e) {
+      this.logger.log("Error parsing $admin message:");
+      this.logger.log(e);
+      throw new Error(
+        "Could not parse your admin message. It should be in the format "
+        + "`$admin supersecretkey1234`. The key may not contain spaces.");
+    }
+
+    if (code !== this.code) {
+      throw new Error(
+        "The code you entered does not match the correct admin code.");
+    }
+
+    this.setAdminUser(message.author);
+  }
+
+}
+
+module.exports = Admin;

--- a/src/Admin.js
+++ b/src/Admin.js
@@ -60,6 +60,10 @@ class Admin {
    * @return {boolean}
    */
   isAdminUser(user) {
+    if (!this.hasAdminUser()) {
+      return false;
+    }
+
     return user.id === this.adminUser.id;
   }
 

--- a/src/MessageHandler.js
+++ b/src/MessageHandler.js
@@ -132,6 +132,14 @@ class MessageHandler {
       } catch (e) {
         this.reply(e.message);
       }
+    } else if(messageContent.match(/^qqq/)) {
+      if (!this.adminManager.isAdminUser(message.author)) {
+        this.reply(
+          "Only admins can run that command, and you are not the admin.");
+        return;
+      }
+
+      this.quitTheBot();
     } else {
       // if nothing else, pass through the message to Frotz (assuming
       // Frotz is running
@@ -158,7 +166,21 @@ class MessageHandler {
       channel = this.targetChannel;
     }
 
-    channel.send(message);
+    return channel.send(message);
+  }
+
+  /**
+   * Stops the currently running game, closes the connection to Discord, and
+   * generally wraps up the bot.
+   */
+  async quitTheBot() {
+    await this.reply("The bot is shutting down.");
+    this.closeGame();
+    this.client.destroy();
+    console.log(
+      "An admin user invoked $qqq. As a result, the game has been closed and "
+      + "the Discord client has been destroyed. The bot will now shut down.");
+    process.kill(0);
   }
 
   /**

--- a/src/MessageHandler.js
+++ b/src/MessageHandler.js
@@ -29,7 +29,8 @@ class MessageHandler {
     this.commandPrefix = this.appConfig.settings.commandPrefix;
     this.commentPrefix = this.appConfig.settings.commentPrefix;
     this.storageManager = new StorageManager("main");
-    this.adminManager = new Admin(client, this.storageManager, logger);
+    this.adminManager =
+      new Admin(client, this.storageManager, logger, appConfig);
 
     this.loadFromStorage();
   }

--- a/src/MessageHandler.js
+++ b/src/MessageHandler.js
@@ -1,5 +1,6 @@
 const StorageManager = require("./../utility/StorageManager");
 const StringDecoder = require("string_decoder").StringDecoder;
+const Admin = require("./Admin");
 const decoder = new StringDecoder("utf8");
 const fs = require("fs");
 var utf8 = require("utf8");
@@ -28,6 +29,7 @@ class MessageHandler {
     this.commandPrefix = this.appConfig.settings.commandPrefix;
     this.commentPrefix = this.appConfig.settings.commentPrefix;
     this.storageManager = new StorageManager("main");
+    this.adminManager = new Admin(client, this.storageManager, logger);
 
     this.loadFromStorage();
   }
@@ -122,6 +124,13 @@ class MessageHandler {
     } else if(messageContent.match(/^(save)/i)) {
       // disable saving for now
       this.reply("Saving is disabled for now.");
+    } else if(messageContent.match(/^admin /)) {
+      try {
+        this.adminManager.setAdminUserFromMessage(message);
+        this.reply("You are now set as the bot admin.");
+      } catch (e) {
+        this.reply(e.message);
+      }
     } else {
       // if nothing else, pass through the message to Frotz (assuming
       // Frotz is running

--- a/test/DiscordClientMock.js
+++ b/test/DiscordClientMock.js
@@ -2,6 +2,8 @@ class DiscordClientMock {
 
   constructor() {
     this.user = new DiscordUserMock();
+    this.users = new CollectionMock();
+    this.channels = new CollectionMock();
     this.lastMessage = null;
   }
 
@@ -22,6 +24,14 @@ class DiscordClientMock {
     return new DiscordChannelMock(this);
   }
 
+}
+
+class CollectionMock {
+  fetch() {
+    return new Promise((resolve) => {
+      resolve(null);
+    });
+  }
 }
 
 class DiscordChannelMock {


### PR DESCRIPTION
Adds `$qqq` and `$admin` commands to the bot.

`$admin` allows users to set themself as the bot admin (assuming they specify the right code).

`$qqq`, which is only allowed to be run by admins, stops the currently running game and kills the bot.

Closes #44 